### PR TITLE
feat: Inject latex into math nodes

### DIFF
--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -1,3 +1,10 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))
+
+(math
+  (content) @injection.content
+  (#set! injection.language "latex"))
+
 (code_block
   (language) @injection.language
   (code) @injection.content)


### PR DESCRIPTION
The `latex` grammar seems to highlight inline math too, so I think it's fine to inject it straight into `math` nodes.

Closes https://github.com/treeman/tree-sitter-djot/issues/21

